### PR TITLE
0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Therefore, I decided to make my own.
 
 - [anytree](https://github.com/c0fec0de/anytree) - Very hackable, but generally slow.
 - [bigtree](https://github.com/kayjan/bigtree) - Similar to anytree, but has more features.
-- [itertree](https://github.com/BR1py/itertree) - Has many features. It has good performance, but has a complicated design.
+- [itertree](https://github.com/BR1py/itertree) - Has many features and good performance, but has a complicated design.
 - [treelib](https://github.com/caesar0301/treelib) - This puts all nodes of a tree into a single dict. This makes some operations difficult or slow, although it has advantages too.
 - [networkx](https://networkx.org/) - Is actually made for graphing. Doesn't have a dedicated tree type.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,12 @@
+## Version 0.4.0 ##
+- Improve DotExporter
+  - Rename `name_factory` to `node_name`.
+  - Derive file type from file extension instead of assuming png
+  - Add `graph_attributes`
+  - Make attribute handling more intelligent
+  - Add parameter `directed` (default: True)
+  - Remove whitespace around arrows
+
 ## Version 0.3.0 ##
 - Remove `tree.show(img=True)`. Use `tree.to_image().show()` instead.
 - New method `tree.transform()` that creates a modified or pruned copy of a tree.

--- a/changes.md
+++ b/changes.md
@@ -8,6 +8,7 @@
   - Remove whitespace around arrows for compacter file size.
 - Add MermaidExporter. Similar to DotExporter, but supported by [github](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).
 - Make `tree.children` writable for more compatibility with anytree/bigtree
+- Add parameters `backend` and `node_label` to `tree.to_image()`
 
 ## Version 0.3.0 ##
 - Remove `tree.show(img=True)`. Use `tree.to_image().show()` instead.

--- a/changes.md
+++ b/changes.md
@@ -1,11 +1,13 @@
 ## Version 0.4.0 ##
 - Improve DotExporter
   - Rename `name_factory` to `node_name`.
-  - Derive file type from file extension instead of assuming png
-  - Add `graph_attributes`
-  - Make attribute handling more intelligent
-  - Add parameter `directed` (default: True)
-  - Remove whitespace around arrows
+  - Derive file type from file extension if possible. Fall back on png.
+  - Add `graph_attributes`.
+  - Make attribute handling more intelligent. Distinguish static and dynamic properties.
+  - Add parameter `directed` (default: True).
+  - Remove whitespace around arrows for compacter file size.
+- Add MermaidExporter. Similar to DotExporter, but supported by [github](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).
+- Make `tree.children` writable for more compatibility with anytree/bigtree
 
 ## Version 0.3.0 ##
 - Remove `tree.show(img=True)`. Use `tree.to_image().show()` instead.

--- a/littletree/__init__.py
+++ b/littletree/__init__.py
@@ -8,4 +8,4 @@ __all__ = [
     "MaxDepth"
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/littletree/basenode.py
+++ b/littletree/basenode.py
@@ -149,6 +149,20 @@ class BaseNode(Generic[TIdentifier]):
             children = self._cvalues = self._cdict.values()
             return children
 
+    @children.setter
+    def children(self, new_children):
+        old_children = list(self.children)
+        self.clear()
+        try:
+            self.update(new_children)
+        except LoopError as err:
+            self.update(old_children)
+            raise err from None
+
+    @children.deleter
+    def children(self):
+        self.clear()
+
     @property
     def path(self) -> NodePath:
         try:

--- a/littletree/exporters/__init__.py
+++ b/littletree/exporters/__init__.py
@@ -1,7 +1,9 @@
 __all__ = [
     "StringExporter",
     "DotExporter",
+    "MermaidExporter",
 ]
 
 from .dotexporter import DotExporter
+from .mermaidexporter import MermaidExporter
 from .stringexporter import StringExporter

--- a/littletree/exporters/dotexporter.py
+++ b/littletree/exporters/dotexporter.py
@@ -14,7 +14,6 @@ from ..basenode import BaseNode
 
 
 TNode = TypeVar("TNode", bound=BaseNode)
-Arrow = Union[str, Callable[[TNode, TNode], str]]
 NodeAttributes = Union[Mapping[str, Any], Callable[[TNode], Mapping[str, Any]]]
 EdgeAttributes = Union[Mapping[str, Any], Callable[[TNode, TNode], Mapping[str, Any]]]
 GraphAttributes = Mapping[str, Any]
@@ -47,7 +46,7 @@ class DotExporter:
         self.directed = directed
         self.dot_path = Path(dot_path)
 
-    def to_image(self, tree: TNode, file=None, keep=None, file_format="png", as_bytes=False):
+    def to_image(self, tree: TNode, file=None, keep=None, file_format=None, as_bytes=False):
         """Export tree to an image
 
         If file is None and not as_bytes, it will return a Pillow object [default].
@@ -152,7 +151,7 @@ class DotExporter:
         cls,
         attributes: Union[NodeAttributes, EdgeAttributes, GraphAttributes],
         *args
-    ):
+    ) -> str:
         """
         Attributes can be:
         - Dict [str, (Any | TNode -> Any)]

--- a/littletree/exporters/dotexporter.py
+++ b/littletree/exporters/dotexporter.py
@@ -74,7 +74,8 @@ class DotExporter:
 
         try:
             args = [self.dot_path, "-T", file_format]
-            process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=file)
+            process = subprocess.Popen(args,
+                                       stdin=subprocess.PIPE, stdout=file, stderr=subprocess.PIPE)
         except FileNotFoundError as err:
             raise Exception("Install dot from graphviz.org") from err
 

--- a/littletree/exporters/elements.py
+++ b/littletree/exporters/elements.py
@@ -1,0 +1,9 @@
+class Literal:
+    """Literal value to insert into Graphviz or Mermaid."""
+    __slots__ = "value"
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return str(self.value)

--- a/littletree/exporters/mermaidexporter.py
+++ b/littletree/exporters/mermaidexporter.py
@@ -1,0 +1,120 @@
+import operator
+from typing import Callable, Union, TypeVar, Tuple, Optional
+
+from .elements import Literal
+from ..basenode import BaseNode
+
+TNode = TypeVar("TNode", bound=BaseNode)
+TShape = Union[
+    Tuple[str, str], str,
+    Callable[[TNode], Union[Tuple[str, str], str]]
+]
+
+# Provide normal names for shapes (dot syntax is saner than mermaid)
+DEFAULT_SHAPES = {
+    "box": ("[", "]"),
+    "rectangle": ("[", "]"),
+    "round": ("(", ")"),
+    "stadium": ("([", "])"),
+    "subroutine": ("[[", "]]"),
+    "asymmetric": (">", "]"),
+    "circle": ("((", "))"),
+    "double-circle": ("(((", ")))"),
+    "rhombus": ("{", "}"),
+    "hexagon": ("{{", "}}"),
+    "parallelogram": ("[/", "/]"),
+    "inv-parallelogram": ("[\\", r"\]"),
+    "trapezium": ("[/", r"\]"),
+    "inv-trapezium": ("[\\", "/]"),
+}
+
+
+class MermaidExporter:
+    """Exporter for mermaid diagrams."""
+    def __init__(
+        self,
+        node_name: Union[str, Callable[[TNode], str], None] = None,
+        node_label: Union[str, Callable[[TNode], str], None] = str,
+        node_shape: TShape = "square",
+        edge_arrow: Union[str, Callable[[TNode, TNode], str]] = "-->",
+        graph_direction: str = "TD",
+    ):
+        def default_node_name(node):
+            return hex(id(node))
+
+        self.node_name = self._make_callable(node_name) or default_node_name
+        self.node_label = self._make_callable(node_label)
+        self.node_shape = node_shape
+        self.edge_arrow = edge_arrow
+        self.graph_direction = graph_direction
+
+    def to_mermaid(self, tree: TNode, file=None, keep=None):
+        output = self._to_mermaid(tree, keep)
+
+        if file is None:
+            return "\n".join(output)
+        elif hasattr(file, "write"):
+            file.writelines(output)
+        else:
+            with open(file, "w", encoding='utf-8') as fp:
+                fp.writelines(output)
+
+    def _to_mermaid(self, root, keep=None):
+        node_name = self.node_name
+        node_label = self.node_label
+        node_shape = self.node_shape
+        edge_arrow = self.edge_arrow
+        if isinstance(node_shape, str):
+            node_shape = DEFAULT_SHAPES[node_shape]
+        get_shape = self._get_shape
+        escape_string = self._escape_string
+
+        # Output header
+        yield f"graph {self.graph_direction}"
+
+        # Output nodes
+        for node in root.iter_tree(keep):
+            left, right = get_shape(node_shape, node)
+            name = node_name(node)
+            if node_label:
+                text = escape_string(node_label(node))
+                yield f"{name}{left}{text}{right}"
+            else:
+                yield f"{name}"
+
+        # Output edges
+        for node in root.iter_descendants(keep):
+            arrow = edge_arrow(node.parent, node) if callable(edge_arrow) else edge_arrow
+            parent = node_name(node.parent)
+            child = node_name(node)
+            yield f"{parent}{arrow}{child}"
+
+    @staticmethod
+    def _get_shape(shape_factory, node):
+        if callable(shape_factory):
+            shape = shape_factory(node)
+            if isinstance(shape, str):
+                shape = DEFAULT_SHAPES[shape]
+        else:
+            shape = shape_factory
+        return shape
+
+    @staticmethod
+    def _escape_string(text) -> str:
+        if isinstance(text, Literal):
+            return str(text)
+        text = str(text)
+        text = text.replace('#', "#35;")
+        text = text.replace('`', "#96;")
+        text = text.replace('"', "#quot;")
+        return f'"{text}"'
+
+    @staticmethod
+    def _make_callable(f) -> Optional[Callable]:
+        if not f:
+            f = None
+        elif isinstance(f, str):
+            f = operator.attrgetter(f)
+        elif not callable(f):
+            raise TypeError(f"Parameter should be callable")
+        return f

--- a/littletree/node.py
+++ b/littletree/node.py
@@ -115,20 +115,35 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
         exporter = StringExporter(str_factory=str_factory, **kwargs)
         return exporter.to_string(self, file, keep=keep)
 
-    def to_image(self, file=None, keep=None, node_attributes=None, **kwargs):
+    def to_image(
+        self,
+        file=None,
+        keep=None,
+        node_attributes=None,
+        node_label=str,
+        backend="graphviz",
+        **kwargs
+    ):
         if node_attributes is None:
-            node_attributes = {"label": str}
-        exporter = DotExporter(node_attributes=node_attributes, **kwargs)
+            node_attributes = {"label": node_label}
+        if backend == "graphviz":
+            exporter = DotExporter(node_attributes=node_attributes, **kwargs)
+        elif backend == "mermaid":
+            exporter = MermaidExporter(node_label=node_label, **kwargs)
+            if not file:
+                raise ValueError("Parameter file is required for mermaid")
+        else:
+            raise ValueError(f"Backend should be graphviz or mermaid, not {backend}")
         return exporter.to_image(self, file, keep=keep)
 
-    def to_dot(self, file=None, keep=None, node_attributes=None, **kwargs) -> Optional[str]:
+    def to_dot(self, file=None, keep=None, node_attributes=None, node_label=str, **kwargs) -> Optional[str]:
         if node_attributes is None:
-            node_attributes = {"label": str}
+            node_attributes = {"label": node_label}
         exporter = DotExporter(node_attributes=node_attributes, **kwargs)
         return exporter.to_dot(self, file, keep=keep)
 
-    def to_mermaid(self, file=None, keep=None, **kwargs) -> Optional[str]:
-        exporter = MermaidExporter(**kwargs)
+    def to_mermaid(self, file=None, keep=None, node_label=str, **kwargs) -> Optional[str]:
+        exporter = MermaidExporter(node_label=node_label, **kwargs)
         return exporter.to_mermaid(self, file, keep=keep)
 
     @classmethod

--- a/littletree/node.py
+++ b/littletree/node.py
@@ -4,6 +4,7 @@ from typing import Mapping, Optional, Iterator, TypeVar, Generic, Hashable, Unio
 
 from .basenode import BaseNode
 from .exporters import DotExporter
+from .exporters import MermaidExporter
 from .exporters import StringExporter
 from .serializers import DictSerializer
 from .serializers import NewickSerializer
@@ -126,6 +127,10 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
         exporter = DotExporter(node_attributes=node_attributes, **kwargs)
         return exporter.to_dot(self, file, keep=keep)
 
+    def to_mermaid(self, file=None, keep=None, **kwargs) -> Optional[str]:
+        exporter = MermaidExporter(**kwargs)
+        return exporter.to_mermaid(self, file, keep=keep)
+
     @classmethod
     def from_dict(cls, data, data_field="data", **kwargs) -> TNode:
         return DictSerializer(cls, data_field=data_field, **kwargs).from_dict(data)
@@ -146,7 +151,8 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
         return serializer.from_relations(relations, root)
 
     def to_relations(self, data_field="data", **kwargs):
-        return RelationSerializer(self.__class__, data_field=data_field, **kwargs).to_relations(self)
+        serializer = RelationSerializer(self.__class__, data_field=data_field, **kwargs)
+        return serializer.to_relations(self)
 
     @classmethod
     def from_newick(cls, newick, root=None, data_field="data", **kwargs) -> TNode:

--- a/littletree/node.py
+++ b/littletree/node.py
@@ -76,7 +76,7 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
                 return Node(original.data)
         return self.transform(node)
 
-    def compare(self, other: TNode, keep_equal=False) -> TNode:
+    def compare(self, other: TNode, keep_equal=False) -> Optional[TNode]:
         """Compare two trees to one another.
 
         If diff_only is true, all nodes where data is equal will be removed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/lverweijen/littletree
 description = Tree library
 long_description = file: README.md
 long_description_content_type = text/markdown
-keywords = tree, datastructure, hierarchy, taxonomy, newick, graphviz
+keywords = tree, datastructure, hierarchy, taxonomy, newick, graphviz, mermaid
 license = Apache License 2.0
 classifiers =
     Intended Audience :: Developers

--- a/tests/test_dotexporter.py
+++ b/tests/test_dotexporter.py
@@ -6,15 +6,15 @@ import littletree
 class TestDotExporter(TestCase):
     def test_to_dot(self):
         tree = littletree.Node.from_newick("A(b, c, d)")
-        result = tree.to_dot()
+        result = tree.to_dot(node_name="path")
         expected = (
             'digraph tree {\n'
             '"/A"[label="A"];\n'
             '"/A/b"[label="b"];\n'
             '"/A/c"[label="c"];\n'
             '"/A/d"[label="d"];\n'
-            '"/A" -> "/A/b";\n'
-            '"/A" -> "/A/c";\n'
-            '"/A" -> "/A/d";\n'
+            '"/A"->"/A/b";\n'
+            '"/A"->"/A/c";\n'
+            '"/A"->"/A/d";\n'
             '}')
         self.assertEqual(expected, result)

--- a/tests/test_mermaidexporter.py
+++ b/tests/test_mermaidexporter.py
@@ -10,13 +10,13 @@ class TestMermaidExporter(TestCase):
         exporter = MermaidExporter(node_name="path")
         result = exporter.to_mermaid(tree)
         expected = (
-            'graph TD\n'
-            '/A["A"]\n'
-            '/A/b["b"]\n'
-            '/A/c["c"]\n'
-            '/A/d["d"]\n'
-            '/A-->/A/b\n'
-            '/A-->/A/c\n'
-            '/A-->/A/d')
+            'graph TD;\n'
+            '/A["A"];\n'
+            '/A/b["b"];\n'
+            '/A/c["c"];\n'
+            '/A/d["d"];\n'
+            '/A-->/A/b;\n'
+            '/A-->/A/c;\n'
+            '/A-->/A/d;')
         self.assertEqual(expected, result)
         print(result)

--- a/tests/test_mermaidexporter.py
+++ b/tests/test_mermaidexporter.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+import littletree
+from littletree.exporters import MermaidExporter
+
+
+class TestMermaidExporter(TestCase):
+    def test_to_mermaid(self):
+        tree = littletree.Node.from_newick("A(b, c, d)")
+        exporter = MermaidExporter(node_name="path")
+        result = exporter.to_mermaid(tree)
+        expected = (
+            'graph TD\n'
+            '/A["A"]\n'
+            '/A/b["b"]\n'
+            '/A/c["c"]\n'
+            '/A/d["d"]\n'
+            '/A-->/A/b\n'
+            '/A-->/A/c\n'
+            '/A-->/A/d')
+        self.assertEqual(expected, result)
+        print(result)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -2,6 +2,7 @@ import copy
 from unittest import TestCase
 
 from littletree import Node
+from littletree.exceptions import LoopError
 
 
 class TestNode(TestCase):
@@ -76,6 +77,20 @@ class TestNode(TestCase):
 
         self.assertTrue(other_tree.is_leaf)
         self.assertEqual(expected, result)
+
+    def test_reassign_children(self):
+        tree = self.tree
+        children = list(tree.children)
+        children = reversed(children)
+        tree.children = children
+        tree.show()
+        result = [str(child.path) for child in tree.children]
+        expected = ['/world/Africa', '/world/Europe']
+        self.assertEqual(expected, result)
+
+    def test_reassign_children_error(self):
+        with self.assertRaises(LoopError):
+            self.tree['Europe'].children = [self.tree.root]
 
     def test_sort_children1(self):
         tree = self.tree

--- a/tutorial.md
+++ b/tutorial.md
@@ -195,12 +195,12 @@ Nodes have basic import and exports options with many parameters:
 | Format | Function                          | Use                                     |
 |--------|-----------------------------------|-----------------------------------------|
 | Text   | to_string()                       | Pretty print the tree                   |
-| Image  | to_dot(), to_image()              | Exports to image (requires graphviz)    |
+| Text   | to_dot(), to_mermaid()            | Exports to dot/mermaid                  |
+| Image  | to_image()                        | Requires graphviz or mermaid            |
 | Nested | from_dict() / to_dict()           | Converting to / from json-like formats  |
 | Rows   | from_rows() / to_rows()           | Converting to / from path lists         |
 | Rows   | from_relations() / to_relations() | Converting to / from parent-child lists |
 | Text   | from_newick() / to_newick()       | Converting to / from newick-format      |
-| Text   | to_mermaid()                      | Exports to mermaid                      |
 
 ```python
 family_newick = "((George, Charlotte, Louis)William,(Archie, Lilibet)Harry)'Charles III'[&&NHX:born=1948]"

--- a/tutorial.md
+++ b/tutorial.md
@@ -200,6 +200,7 @@ Nodes have basic import and exports options with many parameters:
 | Rows   | from_rows() / to_rows()           | Converting to / from path lists         |
 | Rows   | from_relations() / to_relations() | Converting to / from parent-child lists |
 | Text   | from_newick() / to_newick()       | Converting to / from newick-format      |
+| Text   | to_mermaid()                      | Exports to mermaid                      |
 
 ```python
 family_newick = "((George, Charlotte, Louis)William,(Archie, Lilibet)Harry)'Charles III'[&&NHX:born=1948]"


### PR DESCRIPTION
## Version 0.4.0 ##
- Improve DotExporter
  - Rename `name_factory` to `node_name`.
  - Derive file type from file extension if possible. Fall back on png.
  - Add `graph_attributes`.
  - Make attribute handling more intelligent. Distinguish static and dynamic properties.
  - Add parameter `directed` (default: True).
  - Remove whitespace around arrows for compacter file size.
- Add MermaidExporter. Similar to DotExporter, but supported by [github](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).
- Make `tree.children` writable for more compatibility with anytree/bigtree