### PR TITLE
0.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ It can be used to represent file systems, taxonomies and much more.
 
 ## Features ##
 
-- Intuitive dict-like usage for creating and modifying trees.
+- Dict-like usage for basic creation and modification of trees.
 - Performant implementation of common tree operations and traversals.
-- Easy to subclass from. It's even possible to make it use a different dict backend ([indexed.Dict](https://pypi.org/project/indexed/), [SortedDict](https://grantjenks.com/docs/sortedcontainers/)).
-- Can handle big trees even if they are 10,000 layers deep.
+- Can be subclassed. It's possible to make subclasses use a different dict backend ([indexed.Dict](https://pypi.org/project/indexed/), [SortedDict](https://grantjenks.com/docs/sortedcontainers/)).
+- Can handle big trees that are 10,000 layers deep.
 - Can be imported / exported to many different formats (nested dict, rows, relations, graphviz, mermaid, newick, networkx).
 - Purely written in Python.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 LittleTree is a library that provides a tree data structure to python.
 The package is purely written in python.
-It should be easy to use while efficient.
+It should be intuivive to use while performant.
 
 ## Installing ##
 
@@ -22,8 +22,11 @@ tree["Africa"] = Node()
 tree["America"] = Node()
 tree["Europe"] = Node()
 
-tree.show()  # Same as print(tree.to_string())
-tree.to_image().show()  # Show as an image instead
+# Print tree to console
+tree.show()
+
+# Show tree as an image
+tree.to_image().show()
 ```
 
 The resulting tree is printed like this:
@@ -42,19 +45,20 @@ And it creates the following image:
 
 See [tutorial](https://github.com/lverweijen/littletree/blob/main/tutorial.md) for more information.
 
+## Features ##
+
+- Intuitive dict-like usage for creating and modifying trees.
+- Performant implementation of common operations and tree traversals.
+- Easy to subclass from. It's even possible to make it use a different dict backend ([indexed.Dict](https://pypi.org/project/indexed/), [SortedDict](https://grantjenks.com/docs/sortedcontainers/)).
+- Can handle big trees even if they are 10,000 layers deep.
+- Can be imported / exported to many different formats (nested dict, rows, relations, graphviz, mermaid, newick, networkx).
 
 ## Limitations ##
-- Each node has a single parent
-- A node can't have a sibling with the same identifier
+- Each node has at most one parent. (It's a tree not a graph)
+- Different children of the same parent must have different names. (It's not a multidict)
 
-## Alternatives ##
+See further:
+[Pypi](https://pypi.org/project/littletree/) |
+[Github](https://github.com/lverweijen/littletree) |
+[Issues](https://github.com/lverweijen/littletree/issues)
 
-Before creating this, I looked at some other tree libraries.
-I found the others to be lacking, because they were either slow or made simple things complicated.
-Therefore, I decided to make my own.
-
-- [anytree](https://github.com/c0fec0de/anytree) - Very hackable, but generally slow.
-- [bigtree](https://github.com/kayjan/bigtree) - Similar to anytree, but has more features.
-- [itertree](https://github.com/BR1py/itertree) - Has many features and good performance, but has a complicated design.
-- [treelib](https://github.com/caesar0301/treelib) - This puts all nodes of a tree into a single dict. This makes some operations difficult or slow, although it has advantages too.
-- [networkx](https://networkx.org/) - Is actually made for graphing. Doesn't have a dedicated tree type.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 LittleTree is a library that provides a tree data structure to python.
-The package is purely written in python.
-It should be intuivive to use while performant.
+It can be used to represent file systems, taxonomies and much more.
+
+## Features ##
+
+- Intuitive dict-like usage for creating and modifying trees.
+- Performant implementation of common tree operations and traversals.
+- Easy to subclass from. It's even possible to make it use a different dict backend ([indexed.Dict](https://pypi.org/project/indexed/), [SortedDict](https://grantjenks.com/docs/sortedcontainers/)).
+- Can handle big trees even if they are 10,000 layers deep.
+- Can be imported / exported to many different formats (nested dict, rows, relations, graphviz, mermaid, newick, networkx).
+- Purely written in Python.
+
+## Limitations ##
+- Each node has at most one parent. (It's a tree not a graph)
+- Different children of the same parent must have different names. (It's not a multidict)
 
 ## Installing ##
 
@@ -44,18 +56,6 @@ And it creates the following image:
 ![world](world.png)
 
 See [tutorial](https://github.com/lverweijen/littletree/blob/main/tutorial.md) for more information.
-
-## Features ##
-
-- Intuitive dict-like usage for creating and modifying trees.
-- Performant implementation of common operations and tree traversals.
-- Easy to subclass from. It's even possible to make it use a different dict backend ([indexed.Dict](https://pypi.org/project/indexed/), [SortedDict](https://grantjenks.com/docs/sortedcontainers/)).
-- Can handle big trees even if they are 10,000 layers deep.
-- Can be imported / exported to many different formats (nested dict, rows, relations, graphviz, mermaid, newick, networkx).
-
-## Limitations ##
-- Each node has at most one parent. (It's a tree not a graph)
-- Different children of the same parent must have different names. (It's not a multidict)
 
 See further:
 [Pypi](https://pypi.org/project/littletree/) |

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,8 @@
 - Add `NetworkXSerializer` for conversion to and from [networkx](https://networkx.org/).
 - Faster implementation of `__eq__` for deep trees.
 - Two trees can now be equal (`==`) if their roots have a different identifier. 
+- Replace argument `str_factory` by `formatter` in `tree.show()` and `tree.to_string`.
+  If passed a string, it will be applied as `formatter.format(node=node)`.
 
 ## Version 0.4.1 ##
 Fix bug in `tree.compare` method

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,8 @@
+## Version 0.5.0 ##
+- Add `NetworkXSerializer` for conversion to and from [networkx](https://networkx.org/).
+- Faster implementation of `__eq__` for deep trees.
+- Two trees can now be equal (`==`) if their roots have a different identifier. 
+
 ## Version 0.4.1 ##
 Fix bug in `tree.compare` method
 

--- a/littletree/__init__.py
+++ b/littletree/__init__.py
@@ -8,4 +8,4 @@ __all__ = [
     "MaxDepth"
 ]
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/littletree/node.py
+++ b/littletree/node.py
@@ -66,13 +66,13 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
         else:
             return NotImplemented
 
-    def show(self, style=None, **kwargs):
+    def show(self, formatter=None, style=None, keep=None):
         """Print this tree. Shortcut for print(tree.to_string())."""
         if sys.stdout:
             if not style:
                 supports_unicode = not sys.stdout.encoding or sys.stdout.encoding.startswith('utf')
                 style = "square" if supports_unicode else "ascii"
-            self.to_string(sys.stdout, style=style, **kwargs)
+            self.to_string(sys.stdout, formatter=formatter, style=style, keep=keep)
 
     def copy(self, memo=None) -> TNode:
         """Make a shallow copy or deepcopy if memo is passed."""
@@ -87,7 +87,7 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
     def compare(self, other: TNode, keep_equal=False) -> Optional[TNode]:
         """Compare two trees to one another.
 
-        If diff_only is true, all nodes where data is equal will be removed.
+        If keep_equal is False (default), all nodes where data is equal will be removed.
 
         >>> tree = Node('apples', identifier='fruit')
         >>> other_tree = Node('oranges')
@@ -119,8 +119,8 @@ class Node(BaseNode[TIdentifier], Generic[TIdentifier, TData]):
                 return None  # Trees are perfectly equal
         return diff_tree
 
-    def to_string(self, file=None, keep=None, str_factory=None, **kwargs) -> Optional[str]:
-        exporter = StringExporter(str_factory=str_factory, **kwargs)
+    def to_string(self, file=None, formatter=None, style="square", keep=None) -> Optional[str]:
+        exporter = StringExporter(formatter, style)
         return exporter.to_string(self, file, keep=keep)
 
     def to_image(


### PR DESCRIPTION
- Add `NetworkXSerializer` for conversion to and from [networkx](https://networkx.org/).
- Faster implementation of `__eq__` for deep trees.
- Two trees can now be equal (`==`) if their roots have a different identifier. 
- Replace argument `str_factory` by `formatter` in `tree.show()` and `tree.to_string`.
  If passed a string, it will be applied as `formatter.format(node=node)`.